### PR TITLE
Decrease top margin of question area and display scrollbars if necessary

### DIFF
--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -202,8 +202,9 @@ body {
 
 /* questionnaire blocks */
 #blocks {
-    padding: 160px 80px 0 60px;
+    padding: 40px 80px 0 60px;
     height: calc(100vh - 220px);
+    overflow-y: auto;
 }
 
 #blocks .panel {


### PR DESCRIPTION
With this change, the question area will no longer be cut-off when the window is not high enough.

Fixes #29 