### PR TITLE
Various design fixes

### DIFF
--- a/cysec_backend/src/main/resources/templates/coaching/pagination.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/pagination.jsp
@@ -20,8 +20,8 @@
 
     <div id="pagination-next" class="col-xs-4 text-right">
         <h4 id="next-question" class="next-question">
-            <a href="${baseUrl}${it.next}" style="cursor: pointer;">${it.msg.next}
-                <img src="${baseUrl}/assets/arrow_blue.png" width="36px" height="36px"/>
+            <a href="${baseUrl}${it.next}">${it.msg.next}
+                <img src="${baseUrl}/assets/arrow_blue.png"/>
             </a>
         </h4>
     </div>

--- a/cysec_backend/src/main/resources/templates/coaching/question.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/question.jsp
@@ -6,27 +6,25 @@
 
 <div id="blocks">
     <div class="col-xs-12 container question panel" id="${ question.getId() }}">
-        <!-- question attachment -->
-        <h1 class="row panel-heading">${ question.getText() }</h1>
+        <h1 class="panel-heading">${ question.getText() }</h1>
         <c:set var="qAttachments" value="${ question.getAttachments() }"/>
         <c:if test="${ qAttachments != null }">
+            <div class="row">
             <c:forEach var="qAttachment" items="${ qAttachments.getAttachment() }">
                 <div class="col-lg-6">
                     <img src="data:${ qAttachment.getMime() };base64, ${ qAttachment.getContent().getValue() }"
                          width="50"/>
                 </div>
             </c:forEach>
+            </div>
         </c:if>
-        <!-- answer layout -->
-        <div class="row">
+        <div>
             <jsp:include page="questions/${ question.getType() }.jsp"/>
         </div>
-        <!-- read more -->
         <c:if test="${ question.getReadMore() != null}">
-            <div class="row">
-                <!-- Bootstrap collapse wont work -->
-                <a href="javascript:;" onclick="readMore()">${it.msg.readmore}</a>
-                <div class="readmore">
+            <div class="readmore-container">
+                <a href="#" onclick="toggleReadMore()">${it.msg.readmore}</a>
+                <div class="readmore-box">
                         ${ question.getReadMore() }
                 </div>
             </div>

--- a/cysec_backend/src/main/resources/templates/coaching/questions/text.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/questions/text.jsp
@@ -8,10 +8,9 @@
 
 <!-- Text -->
 <div class="row">
-    <div class="col-xs-12 no-padding-left">
+    <div class="col-xs-12">
         <c:set var="content" value="${answer != null ? answer.getText() : '' }" />
-        <textarea name="${qid}" style="padding: 5px; margin: 15px;" rows="8" cols="70"
-                  onchange="updateAnswer(event)">${content}
-        </textarea>
+        <textarea name="${qid}" style="padding: 5px;" rows="8" cols="70"
+                  onchange="updateAnswer(event)">${content}</textarea>
     </div>
 </div>

--- a/cysec_backend/src/main/resources/templates/dashboard/dashboard.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/dashboard.jsp
@@ -12,10 +12,10 @@
         <%@include file="remaining.jsp"%>
     </div>
     <div id="sidebar-wrapper" class="col-xs-4 bg-lightbluegrey">
-        <ul class="sidebar-nav sidebar-content" id="sidebar-nav sidebar-content">
+        <div class="sidebar-nav sidebar-content">
             <%@include file="sidebar/skillboard.jsp"%>
             <%@include file="sidebar/grades.jsp"%>
             <%@include file="sidebar/badges.jsp"%>
-        </ul>
+        </div>
     </div>
 </div>

--- a/cysec_backend/src/main/resources/templates/dashboard/recommended.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/recommended.jsp
@@ -8,7 +8,7 @@
         <c:choose>
             <c:when test="${ not empty recommendations }">
                 <c:forEach var="item" items="${ recommendations }">
-                    <div class="col-xs-4 col-sm-4 ">
+                    <div class="col-sm-12 col-md-6 col-lg-4">
                         <c:set var="link" value="${item.getLink()}" />
                         <c:set var="prefix" value="ext" />
                         <c:set var="url" value="${link.startsWith('ext ')
@@ -30,7 +30,7 @@
                 </c:forEach>
             </c:when>
             <c:otherwise>
-                <div class="col-xs-4 col-sm-4 ">
+                <div class="col-sm-12 col-md-6 col-lg-4">
                     <a class="recommended-action-wrapper" href="">
                         <div class="recommended-action">
                             <img src="../assets/recommendation_bulb.png" class="recommended-action-icon">

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/badges.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/badges.jsp
@@ -1,5 +1,5 @@
 <h4 class="text-center padding-top-large">
-    <a id="sidebar-title" href="#">${it.msg.latestAchievements}</a>
+    ${it.msg.latestAchievements}
 </h4>
 <li class="sidebar-brand bg-white padding-top-small">
     <!-- Badge -->
@@ -20,7 +20,6 @@
             </c:otherwise>
         </c:choose>
     </div>
-
     <!-- END Badge -->
     <div class="text-right textlink">
     <a href="${pageContext.request.contextPath}/app/badges.jsp">${it.msg.showAll}

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/badges.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/badges.jsp
@@ -1,14 +1,14 @@
 <h4 class="text-center padding-top-large">
     ${it.msg.latestAchievements}
 </h4>
-<li class="sidebar-brand bg-white padding-top-small">
+<div class="sidebar-brand bg-white sidebar-box-padding-x padding-top-small">
     <!-- Badge -->
     <div class="row">
         <c:choose>
             <c:when test="${not empty it.badges}">
                 <c:forEach var="badge" items="${it.badges}">
                     <c:if test="${not empty badge.getImagePath()}">
-                        <div class="col-sm-4">
+                        <div class="col-xs-12 col-sm-4">
                             <img src="${scheme.concat(host).concat(api).concat(badge.getImagePath())}">
                                 <%--                    <div>${ badge.getName() }</div>--%>
                         </div>
@@ -16,7 +16,7 @@
                 </c:forEach>
             </c:when>
             <c:otherwise>
-                <div>${it.msg.noAchievements}</div>
+                <div class="col-xs-12">${it.msg.noAchievements}</div>
             </c:otherwise>
         </c:choose>
     </div>
@@ -26,4 +26,4 @@
     <img src="../assets/arrow_blue.svg" width="24px" height="24px"/>
     </a>
     </div>
-</li>
+</div>

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/grades.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/grades.jsp
@@ -1,7 +1,7 @@
 <h4 class="text-center padding-top-large">
     ${it.msg.achievedLevels}
 </h4>
-<li class="sidebar-brand bg-white margin-bottom-large">
+<div class="sidebar-brand bg-white sidebar-box-padding-x margin-bottom-large">
     <c:set var="flag" value="${ true }" />
     <c:forEach var="coach" items="${ it.instantiated }">
         <c:set var="rating" value="${coach.getRating()}" />
@@ -14,7 +14,9 @@
         </c:if>
     </c:forEach>
     <c:if test="${ flag }">
-        <div>${it.msg.noLevels}</div>
+        <div class="row level-row">
+            <div class="col-xs-12">${it.msg.noLevels}</div>
+        </div>
     </c:if>
     <!-- static icons requested for demo at review -->
 <%--    <div>--%>
@@ -44,4 +46,4 @@
 <%--        <img src="../assets/icons/icn_levelC_emtpy.svg" width="32px" height="32px"/>--%>
 <%--        <img src="../assets/icons/icn_levelC_emtpy.svg" width="32px" height="32px"/>--%>
 <%--    </div>--%>
-</li>
+</div>

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/grades.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/grades.jsp
@@ -1,5 +1,5 @@
 <h4 class="text-center padding-top-large">
-    <a id="sidebar-title" href="#">${it.msg.achievedLevels}</a>
+    ${it.msg.achievedLevels}
 </h4>
 <li class="sidebar-brand bg-white margin-bottom-large">
     <c:set var="flag" value="${ true }" />

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/skillboard.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/skillboard.jsp
@@ -8,9 +8,7 @@
 
 <li class="sidebar-brand">
     <h4 class="text-center">
-        <a id="sidebar-title" href="#">
-            <c:out value="${it.skills.getFirst()} ${it.msg.skills}"/>
-        </a>
+        <c:out value="${it.skills.getFirst()} ${it.msg.skills}"/>
     </h4>
     <div class="skillboard">
         <div class="padding-top-small padding-bottom-medium">

--- a/cysec_backend/src/main/resources/templates/dashboard/sidebar/skillboard.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/sidebar/skillboard.jsp
@@ -6,27 +6,26 @@
 <c:set var="endurance" value="${skills.getEndurance()}"/>
 <c:set var="image" value="${skills.getImage()}"/>
 
-<li class="sidebar-brand">
+<div class="sidebar-brand">
     <h4 class="text-center">
         <c:out value="${it.skills.getFirst()} ${it.msg.skills}"/>
     </h4>
     <div class="skillboard">
-        <div class="padding-top-small padding-bottom-medium">
-            <img src="${not empty image ? scheme.concat(host).concat(api).concat(image) : '../assets/skillboard.png'}">
+        <div class="padding-top-small padding-bottom-medium text-center">
+            <img class="skill-image" src="${not empty image ? scheme.concat(host).concat(api).concat(image) : '../assets/skillboard.png'}">
         </div>
-
         <!-- strength -->
         <div class="row padding-bottom-small">
-            <div class="col-xs-3 text-left no-padding-left">
+            <div class="col-xs-3 text-left">
                 <p class="skilllevel skill-strength">&nbsp;&nbsp;Lvl. 1</p>
             </div>
             <div class="col-xs-6">
                 <p class="text-center">${it.msg.strength}</p>
             </div>
-            <div class="col-xs-3 no-padding-right text-right">
+            <div class="col-xs-3 text-right">
                 <p class="skilllevel skill-info"></p>
             </div>
-            <div class="col-xs-12 no-padding-left no-padding-right">
+            <div class="col-xs-12">
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" style="width: ${strength / strengthMax * 100}%;"
                      aria-valuenow="${strength}" aria-valuemin="0" aria-valuemax="${strengthMax}">
@@ -37,16 +36,16 @@
         </div>
         <!-- know how -->
         <div class="row padding-bottom-small">
-            <div class="col-xs-3 text-left no-padding-left">
+            <div class="col-xs-3 text-left">
                 <p class="skilllevel skill-knowhow">&nbsp;&nbsp;Lvl. 1</p>
             </div>
             <div class="col-xs-6">
                 <p class="text-center">${it.msg.knowHow}</p>
             </div>
-            <div class="col-xs-3 no-padding-right text-right">
+            <div class="col-xs-3 text-right">
                 <p class="skilllevel skill-info"></p>
             </div>
-            <div class="col-xs-12 no-padding-left no-padding-right">
+            <div class="col-xs-12">
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" style="width: ${knowHow / knowHowMax * 100}%;"
                          aria-valuenow="${knowHow}" aria-valuemin="0" aria-valuemax="${knowHowMax}"></div>
@@ -56,17 +55,16 @@
         </div>
         <!-- endurance/fitness -->
         <div class="row padding-bottom-small">
-            <div class="col-xs-3 text-left no-padding-left">
+            <div class="col-xs-3 text-left">
                 <p class="skilllevel skill-fitness">&nbsp;&nbsp;Lvl. 1</p>
             </div>
             <div class="col-xs-6">
                 <p class="text-center">${it.msg.fitness}</p>
             </div>
-            <div class="col-xs-3 no-padding-right text-right">
+            <div class="col-xs-3 text-right">
                 <p class="skilllevel skill-info"></p>
             </div>
-            <div class="col-xs-12 no-padding-left no-padding-right">
-
+            <div class="col-xs-12">
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" style="width: ${endurance / 30 * 100}%;"
                          aria-valuenow="${endurance}" aria-valuemin="0" aria-valuemax="100"></div>
@@ -74,4 +72,4 @@
             </div>
         </div>
     </div>
-</li>
+</div>

--- a/cysec_backend/src/main/webapp/app/js/coach.js
+++ b/cysec_backend/src/main/webapp/app/js/coach.js
@@ -46,8 +46,8 @@ const updateAnswer = (event) => {
     });
 };
 
-const readMore = (event) => {
-    const elem = $(".readmore");
+const toggleReadMore = (event) => {
+    const elem = $(".readmore-box");
     elem.css('visibility', elem.css('visibility') === 'hidden' ? 'visible' : 'hidden');
 };
 

--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -194,7 +194,7 @@ body {
 
 /* questionnaire blocks */
 #blocks {
-    padding: 40px 80px 0 60px;
+    padding: 40px 65px 0 45px;
     height: calc(100vh - 220px);
     overflow-y: auto;
 }
@@ -884,9 +884,12 @@ body {
     max-width: 250px;
 }
 
-.readmore {
+.readmore-container {
+    padding-top: 20px;
+}
+
+.readmore-box {
     padding: 10px;
-    width: 90%;
     border: 1px solid #007EA7;
     visibility: hidden;
 }

--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -156,7 +156,7 @@ body {
 #page-content-wrapper,
 #sidebar-wrapper,
 #alert {
-    padding-top: 70px;
+    padding-top: 85px;
 }
 
 .global-nav + #wrapper #page-content-wrapper,

--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -872,14 +872,16 @@ body {
     transition: all 0.3s ease 0s;
 }
 
-
-
 .skillboard {
     padding-bottom: 10px;
 }
 
 .skillboard img {
     width: 100%;
+}
+
+.skillboard img.skill-image {
+    max-width: 250px;
 }
 
 .readmore {

--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -721,13 +721,11 @@ body {
     font-size: 1.8em;
     font-weight: normal;
     color: #007EA7;
+    cursor: pointer;
 }
 
-#pagination .next-question a::after {
-    content: "";
-    background-image: url(../assets/next.png);
-    height: 48px;
-    width: 48px;
+#pagination .next-question a img {
+    max-height: 0.8em;
 }
 
 #pagination .next-question a:hover {

--- a/cysec_backend/src/main/webapp/public/css/simple-sidebar.css
+++ b/cysec_backend/src/main/webapp/public/css/simple-sidebar.css
@@ -17,7 +17,9 @@ body {
 
 #sidebar-wrapper {
     height: 100%;
-    padding-right: 40px;
+    padding-left: 50px;
+    padding-right: 70px;
+    line-height: 40px;
     -webkit-transition: all 0.5s ease;
     -moz-transition: all 0.5s ease;
     -o-transition: all 0.5s ease;
@@ -36,26 +38,20 @@ body {
     width: 100%;
 }
 
-.sidebar-nav li {
-    padding-right: 25px;
-    padding-left: 25px;
-    line-height: 40px;
-}
-
-.sidebar-nav li a {
+.sidebar-nav a {
     display: inline-block;
     text-decoration: none;
     color: #C9DAEA;
 }
 
-.sidebar-nav li a:hover {
+.sidebar-nav a:hover {
     text-decoration: none;
     color: #fff;
     background: rgba(255,255,255,0.2);
 }
 
-.sidebar-nav li a:active,
-.sidebar-nav li a:focus {
+.sidebar-nav a:active,
+.sidebar-nav a:focus {
     text-decoration: none;
 }
 
@@ -63,11 +59,15 @@ body {
     min-height: 65px;
     font-size: 18px;
     line-height: 1.5em;
-    margin-right: 40px;
 }
 
 .sidebar-nav > .sidebar-brand a:hover {
     background: none;
+}
+
+.sidebar-nav > .sidebar-box-padding-x {
+    padding-left: 15px;
+    padding-right: 15px;
 }
 
 .sidebar-nav h4,
@@ -77,14 +77,12 @@ body {
     text-transform: uppercase;
     letter-spacing: 5px;
     padding: 15px 0 5px;
-    margin-left: -20px;
 }
 
 .sidebar-nav h4 a:hover {
     color: #001921;
     text-decoration: none;
 }
-
 
 .sidebar-nav .level-row {
     padding-bottom: 0.5em;


### PR DESCRIPTION
This PR addresses the following improvements and fixes:
- Fix responsive display of recommendations
- Next-button: Scale arrow proportionally, move style to CSS and cleanup unused CSS
- Improve question layout (fixes #34)
- Fix top alignment of first title (heading) in sidebar
- Remove unnecessary nesting of `a`-elements in sidebar
- Convert `ul`/`li`-styling of whole sidebar to `div`-styling
