### PR TITLE
Display only comments for selected answers and add top-padding

### DIFF
--- a/cysec_backend/src/main/resources/templates/coaching/questions/A.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/questions/A.jsp
@@ -26,15 +26,15 @@
     </div>
 
     <!-- option comment -->
-    <div id="comment" class="row" style="display: ${answer != null ? 'block' : 'none'}">
-        <c:if test="${ answer != null }">
+    <c:if test="${answer != null}">
+        <div id="comment" class="row padding-top-small">
             <c:forEach var="option" items="${question.getOptions().getOption()}">
                 <c:if test="${answer.getText().equals(option.getId())}">
                     <div class="col-xs-12">
-                            ${option.getComment()}
+                        ${option.getComment()}
                     </div>
                 </c:if>
             </c:forEach>
-        </c:if>
-    </div>
+        </div>
+    </c:if>
 </div>

--- a/cysec_backend/src/main/resources/templates/coaching/questions/Astar.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/questions/Astar.jsp
@@ -39,9 +39,9 @@
     <!-- option comment -->
     <div>
         <c:forEach var="option" items="${question.getOptions().getOption()}">
-            <c:if test="${option.getComment() != null}">
-                <div id="comment-${option.getId()}" class="row" style="display: ${answer != null ? 'block' : 'none'}" >
-                    <div class="col-xs-12">
+            <c:if test="${answer != null && answer.getAidList().contains(option.getId()) && option.getComment() != null}">
+                <div id="comment-${option.getId()}" class="row">
+                    <div class="col-xs-12 padding-top-small">
                         ${option.getComment()}
                     </div>
                 </div>

--- a/cysec_backend/src/main/resources/templates/coaching/questions/Astarexcl.jsp
+++ b/cysec_backend/src/main/resources/templates/coaching/questions/Astarexcl.jsp
@@ -42,14 +42,13 @@
     <!-- option comment -->
     <div>
         <c:forEach var="option" items="${question.getOptions().getOption()}">
-            <c:if test="${option.getComment()}">
-                <div id="comment-${option.getId()}" class="row" style="display: ${answer != null ? 'block' : 'none'}">
-                    <div class="col-xs-12">
-                        ${option.comment}
+            <c:if test="${answer != null && answer.getAidList().contains(option.getId()) && option.getComment() != null}">
+                <div id="comment-${option.getId()}" class="row">
+                    <div class="col-xs-12 padding-top-small">
+                        ${option.getComment()}
                     </div>
                 </div>
             </c:if>
         </c:forEach>
     </div>
 </div>
-


### PR DESCRIPTION
This PR fixes #56 so only the comments for selected options (in case of `A`, `Astar` and `Astarexcl`) will be displayed.

Top padding is added to the comments to add a visual separation between multiple comments for the same question.