### PR TITLE
Improve dashboard layout

### DIFF
--- a/cysec_backend/src/main/java/eu/smesec/platform/messages/DashboardMsg.java
+++ b/cysec_backend/src/main/java/eu/smesec/platform/messages/DashboardMsg.java
@@ -14,17 +14,17 @@ public class DashboardMsg extends Message {
   public DashboardMsg(Locale locale, int instantiated, int remaining, int badges) {
     super(locale);
 
-    messages.put("recommendations", i18n.trn("recommendation", "recommendations", 2L));
-    messages.put("recommendation", i18n.tr("recommendation"));
-    messages.put("noRecommendation", i18n.tr("no recommendations to display"));
+    messages.put("recommendations", i18n.trn("Recommendation", "Recommendations", 2L));
+    messages.put("recommendation", i18n.tr("Recommendation"));
+    messages.put("noRecommendation", i18n.tr("No recommendations available"));
     messages.put(
         "noRecommendationInfo",
-        i18n.tr("Later you will see recommended next steps displayed here"));
-    messages.put("coaches", i18n.trn("coach", "coaches", instantiated));
+        i18n.tr("If there are recommended next steps, they will be displayed here."));
+    messages.put("coaches", i18n.trn("Coach", "Coaches", instantiated));
     messages.put("coachRestart", i18n.tr("restart"));
     messages.put("coachContinue", i18n.tr("continue"));
-    messages.put("remaining", i18n.trn("remaining coach", "remaining coaches", remaining));
-    messages.put("noRemaining", i18n.tr("All coaches done"));
+    messages.put("remaining", i18n.trn("Remaining coach", "Remaining coaches", remaining));
+    messages.put("noRemaining", i18n.tr("All available coaches started."));
     messages.put("skills", i18n.tr("skills"));
     messages.put("strength", i18n.tr("strength"));
     messages.put("knowHow", i18n.tr("know-how"));

--- a/cysec_backend/src/main/resources/etc/cysec.cfgresources
+++ b/cysec_backend/src/main/resources/etc/cysec.cfgresources
@@ -27,7 +27,7 @@ string; cysec_header_logout;/; Logout URL
 string; cysec_admin_prefix; _admin_; The prefix identifying all admins
 string; cysec_admin_users; admin; Space separated list of admin user names
 string; cysec_admin_passwords; $1$31XX2vnn$NrTMpstqa8SkNneiNdZch0; Space separated list of passwords for the configured admins
-numeric; cysec_recommend_count; 3; The number of recommendations displayed in the dashboard
+numeric; cysec_recommend_count; 6; The number of recommendations displayed in the dashboard
 
 // cysec replica
 string; cysec_replica_host; ; remote context inclusive

--- a/cysec_backend/src/main/resources/po/cysec.pot
+++ b/cysec_backend/src/main/resources/po/cysec.pot
@@ -80,22 +80,22 @@ msgid "next"
 msgstr ""
 
 #: DashboardMsg.java:9 DashboardMsg.java:10
-msgid "recommendation"
-msgid_plural "recommendations"
+msgid "Recommendation"
+msgid_plural "Recommendations"
 msgstr[0] ""
 msgstr[1] ""
 
 #: DashboardMsg.java:11
-msgid "no recommendations to display"
+msgid "No recommendations available"
 msgstr ""
 
 #: DashboardMsg.java:12
-msgid "Later you will see recommended next steps displayed here"
+msgid "If there are recommended next steps, they will be displayed here."
 msgstr ""
 
 #: DashboardMsg.java:13
-msgid "coach"
-msgid_plural "coaches"
+msgid "Coach"
+msgid_plural "Coaches"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -108,13 +108,13 @@ msgid "continue"
 msgstr ""
 
 #: DashboardMsg.java:16
-msgid "remaining coach"
-msgid_plural "remaining coaches"
+msgid "Remaining coach"
+msgid_plural "Remaining coaches"
 msgstr[0] ""
 msgstr[1] ""
 
 #: DashboardMsg.java:17
-msgid "All coaches done"
+msgid "All available coaches started."
 msgstr ""
 
 #: DashboardMsg.java:18

--- a/cysec_backend/src/main/resources/po/de.po
+++ b/cysec_backend/src/main/resources/po/de.po
@@ -75,22 +75,22 @@ msgid "next"
 msgstr "nächste"
 
 #: DashboardMsg.java:9 DashboardMsg.java:10
-msgid "recommendation"
-msgid_plural "recommendations"
+msgid "Recommendation"
+msgid_plural "Recommendations"
 msgstr[0] "Empfehlung"
 msgstr[1] "Empfehlungen"
 
 #: DashboardMsg.java:11
-msgid "no recommendations to display"
-msgstr "keine Empfehlungen anzuzeigen"
+msgid "No recommendations available"
+msgstr "Keine Empfehlungen vorhanden"
 
 #: DashboardMsg.java:12
-msgid "Later you will see recommended next steps displayed here"
-msgstr "Später sehen Sie hier die nächsten empfohlenen Schritte"
+msgid "If there are recommended next steps, they will be displayed here."
+msgstr "Hier werden die nächsten empfohlenen Schritte angezeigt, falls es solche gibt."
 
 #: DashboardMsg.java:13
-msgid "coach"
-msgid_plural "coaches"
+msgid "Coach"
+msgid_plural "Coaches"
 msgstr[0] "Trainer"
 msgstr[1] "Trainer"
 
@@ -103,14 +103,14 @@ msgid "continue"
 msgstr "weitermachen"
 
 #: DashboardMsg.java:16
-msgid "remaining coach"
-msgid_plural "remaining coaches"
-msgstr[0] "ausstehender Trainer"
-msgstr[1] "ausstehende Trainer"
+msgid "Remaining coach"
+msgid_plural "Remaining coaches"
+msgstr[0] "Ausstehender Trainer"
+msgstr[1] "Ausstehende Trainer"
 
 #: DashboardMsg.java:17
-msgid "All coaches done"
-msgstr "Alle Trainer erledigt"
+msgid "All available coaches started."
+msgstr "Alle verfügbaren Trainer wurden bereits gestartet."
 
 #: DashboardMsg.java:18
 msgid "skills"

--- a/cysec_backend/src/main/resources/templates/dashboard/recommended.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/recommended.jsp
@@ -28,25 +28,13 @@
                 </c:forEach>
             </c:when>
             <c:otherwise>
-                <div class="col-sm-12 col-md-6 col-lg-4">
-                    <a class="recommended-action-wrapper" href="">
-                        <div class="recommended-action">
-                            <img src="../assets/recommendation_bulb.png" class="recommended-action-icon">
-                            <h5>${it.msg.recommendation}</h5>
-                            <h3>${it.msg.noRecommendation}</h3>
-                            <p class="recommended-action-description">${it.msg.noRecommendationInfo}.</p>
-                                <%-- Might have to be changed to x-forwarded-proto and x-forwarded-host on prod server--%>
-                            <div class="recommended-action-link">
-                                <img src="../assets/arrow_blue.png" width="28px" height="18px"/>
-                            </div>
-                        </div>
-                    </a>
+                <div class="col-xs-12">
+                    <div class="alert bg-lightbluegrey">
+                        <p><strong>${it.msg.noRecommendation}</strong></p>
+                        <p>${it.msg.noRecommendationInfo}</p>
+                    </div>
                 </div>
-                <!--
-                <div class="text-center">Nothing recommended</div>
-                -->
             </c:otherwise>
         </c:choose>
-        <!-- END Recommendations -->
     </div>
 </div>

--- a/cysec_backend/src/main/resources/templates/dashboard/remaining.jsp
+++ b/cysec_backend/src/main/resources/templates/dashboard/remaining.jsp
@@ -6,7 +6,7 @@
             <c:when test="${ not empty remaining }">
                 <c:forEach var="coach" items="${remaining}">
                     <a href="javascript:;" onclick="instantiate('${coach.getId()}');">
-                        <div class="col-xs-3 col-sm-3">
+                        <div class="col-xs-6 col-md-4">
                             <div class="text-center remaining">
                                 <img src="../assets/badges/badge_access_control.png"/>
                                 <h4>${coach.getReadableName()}</h4>
@@ -16,7 +16,11 @@
                 </c:forEach>
             </c:when>
             <c:otherwise>
-                <div>${it.msg.noRemaining}</div>
+                <div class="col-xs-12">
+                    <div class="alert bg-lightbluegrey">
+                        <p>${it.msg.noRemaining}</p>
+                    </div>
+                </div>
             </c:otherwise>
         </c:choose>
     </div>

--- a/cysec_backend/src/main/webapp/public/css/main.css
+++ b/cysec_backend/src/main/webapp/public/css/main.css
@@ -440,7 +440,7 @@ body {
     color: #7F8C90;
     font-family: 'Renner';
     letter-spacing: 0;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 400;
     text-transform: none;
     text-align: left;


### PR DESCRIPTION
This PR introduces the following changes:

- Show grey box with message when no recommendations are available instead of pseudo-recommendation
- Show grey box with message when no coaches remaining
- Make info text for coaches bigger
- Display 6 recommendations instead of 3 (by default)
- Improve wording on dashboard

Fixes #58 

----

![Screenshot](https://user-images.githubusercontent.com/53262016/132100157-93ce95d6-f78b-4628-82d0-320ab3241140.png)

