### PR TITLE
Add config flag to hide lib-company coach

### DIFF
--- a/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Dashboard.java
+++ b/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Dashboard.java
@@ -70,7 +70,9 @@ import org.glassfish.jersey.server.mvc.Viewable;
 @DenyAll
 @Path("rest/dashboard")
 public class Dashboard {
-  public static final String RECOMMENDATIONS_SIZE = "cysec_recommend_count";
+
+  public static final String CONFIG_RECOMMENDATIONS_COUNT = "cysec_recommend_count";
+  public static final String CONFIG_HIDE_LIB_COMPANY = "cysec_hide_lib_company";
 
   private static Logger logger = Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME);
 
@@ -151,7 +153,15 @@ public class Dashboard {
         }
       }
       List<CoachHelper> instantiated = new ArrayList<>();
-      instantiated.add(coachHelper);
+
+      // Workaround to hide company coach (lib-company) since it currently stores global non-coach data
+      // and therefore needs to be loaded for the platform to work. Once the data is stored in a different
+      // way, this code block can be removed
+      if (!CysecConfig.getDefault().getBooleanValue(contextName, CONFIG_HIDE_LIB_COMPANY)) {
+        instantiated.add(coachHelper);
+      }
+      // End of workaround
+
       FQCN lastSelectedFqcn =
           lastSelected != null ? FQCN.fromString(lastSelected.getCoachId()) : LibCal.FQCN_COMPANY;
       // process other coaches
@@ -220,7 +230,7 @@ public class Dashboard {
       recommendations =
           recommendations.stream()
               .sorted(Comparator.comparingInt(Recommendation::getOrder))
-              .limit(CysecConfig.getDefault().getNumericValue(contextName, RECOMMENDATIONS_SIZE))
+              .limit(CysecConfig.getDefault().getNumericValue(contextName, CONFIG_RECOMMENDATIONS_COUNT))
               .collect(Collectors.toList());
       badges = badges.subList(Integer.max(0, badges.size() - 3), badges.size());
 

--- a/cysec-platform-core/src/main/resources/etc/cysec.cfgresources
+++ b/cysec-platform-core/src/main/resources/etc/cysec.cfgresources
@@ -28,6 +28,7 @@ string; cysec_admin_prefix; _admin_; The prefix identifying all admins
 string; cysec_admin_users; admin; Space separated list of admin user names
 string; cysec_admin_passwords; $1$31XX2vnn$NrTMpstqa8SkNneiNdZch0; Space separated list of passwords for the configured admins
 numeric; cysec_recommend_count; 6; The number of recommendations displayed in the dashboard
+boolean; cysec_hide_lib_company; false; Hide company coach on dashboard (workaround since lib-company stores global non-coach data)
 
 // cysec replica
 string; cysec_replica_host; ; remote context inclusive

--- a/doc/Config.md
+++ b/doc/Config.md
@@ -24,4 +24,5 @@ Fallowing entries are currently used:
 | string | cysec_header_firstname | oidc_claim_given_name | The OAuth firstname |
 | string | cysec_header_lastname | oidc_claim_family_name | The OAuth lastname |
 ||||| 
-|numeric | cysec_recommend_count | 3 | The number of displayed recommendations |
+| numeric | cysec_recommend_count | 3       | The number of displayed recommendations                                                             |
+| boolean | cysec_hide_lib_company | false  | Flag to hide company coach on dashboard (workaround since lib-company stores global non-coach data) |


### PR DESCRIPTION
This PR adds a workaround to hide the company coach (lib-company) since it currently stores global non-coach data and therefore needs to be always loaded for the platform to work.

If the company coach should not be displayed, set the new config parameter `cysec_hide_lib_company` to `true`.

Once the data is stored in a different way, this code block can be removed.

Related to #51 but does not fix it.