### PR TITLE
Add question type 'info' to display an info-text

### DIFF
--- a/cysec-platform-bridge/src/main/resources/questionnaire.xsd
+++ b/cysec-platform-bridge/src/main/resources/questionnaire.xsd
@@ -115,6 +115,9 @@
     <!-- The element to use to accompany questions with counseling/coaching text -->
     <xs:element name="readMore" type="xs:string"/>
 
+    <!-- An infotext to display instead of possible answers/options. -->
+    <xs:element name="infotext" type="xs:string"/>
+
     <!-- The element to use to comment the choice of an option -->
     <xs:element name="comment" type="xs:string"/>
 
@@ -139,6 +142,7 @@
                 <xs:element ref="readMore" minOccurs="0"/>
                 <xs:element ref="attachments" minOccurs="0"/>
                 <xs:element ref="options" minOccurs="0"/>
+                <xs:element ref="infotext" minOccurs="0"/><!-- only relevant for questionType=info -->
                 <xs:element ref="listeners" minOccurs="0"/>
                 <xs:element ref="metadata" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="instruction" minOccurs="0"/>

--- a/cysec-platform-bridge/src/main/resources/questionnaire.xsd
+++ b/cysec-platform-bridge/src/main/resources/questionnaire.xsd
@@ -130,10 +130,7 @@
         </xs:complexType>
     </xs:element>
 
-    <!--
-        A question in the questionnaire, including any attachments and answer options.
-        Types of questions refer to classification from here: https://studmed.unibe.ch/a-z/page.php?id=Pr%FCfungstypen
-     -->
+    <!-- A question in the questionnaire, including any attachments and answer options. -->
     <xs:element name="question">
         <xs:complexType>
             <xs:sequence>
@@ -148,11 +145,18 @@
                 <xs:element ref="instruction" minOccurs="0"/>
             </xs:sequence>
             <xs:attribute name="id" type="xs:ID" use="required"/>
-            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="type" type="questionType" use="required"/>
             <xs:attribute name="hidden" type="xs:boolean" default="true"/>
             <xs:attribute name="extRef" type="xs:string"/>
         </xs:complexType>
     </xs:element>
+
+    <!-- Types of questions refer to classification from here: https://studmed.unibe.ch/a-z/page.php?id=Pr%FCfungstypen -->
+    <xs:simpleType name="questionType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(A|Astar|Astarexcl|date|likert|text|yesno|info)"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <!--
         List of possible answers to a question, including the type of the question and option and, if applicable, a reference

--- a/cysec-platform-core/src/main/resources/templates/coaching/questions/info.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/questions/info.jsp
@@ -1,0 +1,9 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:set var="question" value="${it.question}"/>
+
+<!-- Info -->
+<div class="row">
+    <div class="col-xs-12">
+        ${question.getInfotext()}
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a new question type `info` to display an info-text instead of answer options.

The XSD now restricts the types of supported questions. A restriction by pattern instead of enumeration was used to keep compatibility with existing code.