### PR TITLE
90 text question does not allow certain special characters such as and

### DIFF
--- a/cysec-platform-core/pom.xml
+++ b/cysec-platform-core/pom.xml
@@ -253,6 +253,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.12.0</version>
+        </dependency>
+
         <!-- crypt algorithms for passwords -->
         <dependency>
             <groupId>commons-codec</groupId>

--- a/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Coaches.java
+++ b/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Coaches.java
@@ -66,6 +66,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.server.mvc.Viewable;
 
@@ -240,6 +241,8 @@ public class Coaches {
         return Response.status(404).build();
       }
       CoachLibrary library = cal.getLibrariesForQuestionnaire(coachId).get(0);
+      
+      value = StringEscapeUtils.escapeHtml4(value);      
 
       // check question exists
       Question question = cal.getQuestion(coachId, qid);

--- a/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Coaches.java
+++ b/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/endpoints/Coaches.java
@@ -43,7 +43,6 @@ import eu.smesec.cysec.platform.core.cache.CacheAbstractionLayer;
 import eu.smesec.cysec.platform.core.cache.LibCal;
 import eu.smesec.cysec.platform.core.cache.ResourceManager;
 import eu.smesec.cysec.platform.core.utils.LocaleUtils;
-import eu.smesec.cysec.platform.core.utils.Validator;
 import eu.smesec.cysec.platform.core.json.MValueAdapter;
 import eu.smesec.cysec.platform.core.messages.CoachMsg;
 
@@ -241,11 +240,6 @@ public class Coaches {
         return Response.status(404).build();
       }
       CoachLibrary library = cal.getLibrariesForQuestionnaire(coachId).get(0);
-      // validate response
-      if (!Validator.validateAnswer(value)) {
-        logger.warning("response value is invalid");
-        return Response.status(400).build();
-      }
 
       // check question exists
       Question question = cal.getQuestion(coachId, qid);

--- a/cysec-platform-core/src/main/resources/templates/coaching/questions/text.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/questions/text.jsp
@@ -11,8 +11,7 @@
     <div class="col-xs-12">
         <c:set var="content" value="${answer != null ? answer.getText() : '' }" />
         <textarea name="${qid}" style="padding: 5px;" rows="8" cols="70"
-                  onchange="updateAnswer(event)">
-            <c:out value="${content}" />
+                  onchange="updateAnswer(event)"><c:out value="${content}" escapeXml="false" />
         </textarea>
     </div>
 </div>

--- a/cysec-platform-core/src/main/resources/templates/coaching/questions/text.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/questions/text.jsp
@@ -11,6 +11,8 @@
     <div class="col-xs-12">
         <c:set var="content" value="${answer != null ? answer.getText() : '' }" />
         <textarea name="${qid}" style="padding: 5px;" rows="8" cols="70"
-                  onchange="updateAnswer(event)">${content}</textarea>
+                  onchange="updateAnswer(event)">
+            <c:out value="${content}" />
+        </textarea>
     </div>
 </div>


### PR DESCRIPTION
Proposed solution for #90 : To enable users to input characters like `!`, `?` or `&` removed user text input validation (`/><;?*!&{}` are illegal characters) ~but escape entered text before outputing it in HTML. Before the text is written to the XML file, it is escaped anyway.~ instead escape input.

~Though I doubt it's a good idea to rely solely on output sanitization. @martingwerder opinion?~