### PR TITLE
Fix first click on next is ignored when input changed

### DIFF
--- a/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
@@ -13,7 +13,7 @@
     </div>
     <div class="col-xs-4 text-right">
         <h4 class="next-question">
-            <a href="${baseUrl}${it.next}">${it.msg.next}
+            <a onmousedown="window.location = '${baseUrl}${it.next}'">${it.msg.next}
                 <img src="${baseUrl}/assets/arrow_blue.png"/>
             </a>
         </h4>


### PR DESCRIPTION
- the problem can be reproduced by holding the click for extra-long time
- problem: fetching twice and rerendering can sometimes be faster than the time between `mousedown` and `mouseup` → then the `onclick` event is triggered on a DOM node not existing anymore (see graphic below)
    - [ `onchange`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) an update is submitted to the server and the new page content is fetched. Then the current content is replaced with the incomming content
  - next button is a link (`<a>` tag with `href`) and `onclick` is triggered `onmouseup` so navigating to the other page won't work since the link isn't there anymore since this DOM node was already replaced

![image](https://github.com/cysec-platform/cysec-platform/assets/79504293/b2e46af6-8738-4d8f-a659-59c34328ba82)

* "sloppy" solution: trigger page redirect `onmousedown`. This seams to work but probably just makes the problem less likely to appear. 
  *  drawback: clicking on the next button might feel somewhat "weird"
* a proper solution might be to decouple the pagination (including the next button) from the rest of the content. Since there are further difficulties regarding the next button (e.g. the target of the button) this may have to be done anyway.