### PR TITLE
extend CAL to enable creating / updating answers

### DIFF
--- a/cysec-platform-bridge/src/main/java/eu/smesec/cysec/platform/bridge/ILibCal.java
+++ b/cysec-platform-bridge/src/main/java/eu/smesec/cysec/platform/bridge/ILibCal.java
@@ -65,6 +65,12 @@ public interface ILibCal {
 
   List<Answer> getAllAnswers() throws CacheException;
 
+  void createAnswer(String coachId, Answer answer) throws CacheException;
+
+  void updateAnswer(String coachId, Answer answer) throws CacheException;
+
+  void removeAnswer(String coachId, Object questionId) throws CacheException;
+
   Questionnaire getCoach() throws CacheException;
 
   Questionnaire getCoach(String coachId) throws CacheException;

--- a/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/cache/LibCal.java
+++ b/cysec-platform-core/src/main/java/eu/smesec/cysec/platform/core/cache/LibCal.java
@@ -107,6 +107,21 @@ public class LibCal implements ILibCal {
     return cal.getAllAnswers(getCompanyId(), getCoachContext());
   }
 
+  @Override
+  public void createAnswer(String coachId, Answer answer) throws CacheException {
+    cal.createAnswer(getCompanyId(), FQCN.fromString(coachId), answer);
+  }
+
+  @Override
+  public void updateAnswer(String coachId, Answer answer) throws CacheException {
+    cal.updateAnswer(getCompanyId(), FQCN.fromString(coachId), answer);
+  }
+
+  @Override
+  public void removeAnswer(String coachId, Object questionId) throws CacheException {
+    cal.removeAnswer(getCompanyId(), FQCN.fromString(coachId), questionId);
+  }
+
   /**
    * Deprecated method, this method will be removed in a later release.
    *


### PR DESCRIPTION
Extension is needed to enable make a `setAnswer` command in the coach standard language possible ([see PR](https://github.com/cysec-platform/coach-standard-language/pull/10))