### PR TITLE
Disable next button while posting update

### DIFF
--- a/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
@@ -35,9 +35,10 @@
     </div>
     <div class="col-xs-4 text-right">
         <h4 class="next-question">
-            <a onmousedown="window.location = '${baseUrl}${it.next}'">${it.msg.next}
+            <button id="next-button" onmousedown="window.location = '${baseUrl}${it.next}'">
+                ${it.msg.next}
                 <img src="${baseUrl}/assets/arrow_blue.png"/>
-            </a>
+            </button>
         </h4>
     </div>
 </div>

--- a/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
@@ -38,6 +38,7 @@
             <button id="next-button" onmousedown="window.location = '${baseUrl}${it.next}'">
                 ${it.msg.next}
                 <img src="${baseUrl}/assets/arrow_blue.png"/>
+                <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><style>.spinner_P7sC{transform-origin:center;animation:spinner_svv2 .75s infinite linear}@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style><path d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z" class="spinner_P7sC"/></svg>
             </button>
         </h4>
     </div>

--- a/cysec-platform-core/src/main/webapp/app/js/coach.js
+++ b/cysec-platform-core/src/main/webapp/app/js/coach.js
@@ -41,10 +41,16 @@ const updateAnswer = (event) => {
         if (response.ok) {
             load()
         } else {
-            displayError("Couldn't update answer on: " + url + ": " + response.status);
             console.debug(response.status);
+            displayError("Couldn't update answer on: " + url + ": " + response.status);
+            $("#next-button").prop("disabled", false);
         }
+    }).catch(e => {
+        console.debug(e);
+        $("#next-button").prop("disabled", false);
     });
+    // disable the next button to avoid jumping to the wrong question
+    $("#next-button").prop("disabled", true);
 };
 
 const toggleReadMore = (event) => {

--- a/cysec-platform-core/src/main/webapp/public/css/main.css
+++ b/cysec-platform-core/src/main/webapp/public/css/main.css
@@ -609,6 +609,8 @@ body {
 #pagination {
     padding-top: 30px;
     height: 190px;
+    display: flex;
+    align-items: baseline;
 }
 
 .pagination-element {
@@ -667,7 +669,10 @@ body {
     color: #007EA7;
     background: none;
     border: none;
-    display: inline-block;
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: baseline;
     text-transform: uppercase;
     letter-spacing: 5px;
     text-align: right;

--- a/cysec-platform-core/src/main/webapp/public/css/main.css
+++ b/cysec-platform-core/src/main/webapp/public/css/main.css
@@ -670,15 +670,27 @@ body {
     display: inline-block;
     text-transform: uppercase;
     letter-spacing: 5px;
-    padding: 15px 0;
-}
+    text-align: right;
 
-#pagination .next-question button:disabled {
-    opacity: 0.2;
-}
+    img {
+        max-height: 0.8em;
+    }
+    
+    svg {
+        fill: #007EA7;
+        display: none;
+    }
 
-#pagination .next-question button img {
-    max-height: 0.8em;
+    &:disabled {
+        opacity: 0.2;
+    
+        img {
+            display: none;
+        }
+        svg {
+            display: inline;
+        }
+    }
 }
 
 .question input {

--- a/cysec-platform-core/src/main/webapp/public/css/main.css
+++ b/cysec-platform-core/src/main/webapp/public/css/main.css
@@ -661,19 +661,24 @@ body {
     margin: 0;
 }
 
-#pagination .next-question a {
+#pagination .next-question button {
     font-size: 1.8em;
     font-weight: normal;
     color: #007EA7;
-    cursor: pointer;
+    background: none;
+    border: none;
+    display: inline-block;
+    text-transform: uppercase;
+    letter-spacing: 5px;
+    padding: 15px 0;
 }
 
-#pagination .next-question a img {
+#pagination .next-question button:disabled {
+    opacity: 0.2;
+}
+
+#pagination .next-question button img {
     max-height: 0.8em;
-}
-
-#pagination .next-question a:hover {
-    color: #007EA7;
 }
 
 .question input {


### PR DESCRIPTION

https://github.com/user-attachments/assets/89732072-caa3-4f41-a9f2-a41eac91fd90

When clicking on an option, the update is submitted (`POST`). Then the next button is disabled until the new questionnaire content is rendered (received response from `GET `on `/render`).

This will change slightly again, when the next button becomes "static" and the server decides which question is next. 