### PR TITLE
Static next button

### DIFF
--- a/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
+++ b/cysec-platform-core/src/main/resources/templates/coaching/pagination.jsp
@@ -31,7 +31,7 @@
             </a>
         </c:forEach>
         
-        &nbsp; | &nbsp; <%-- vertical line --%>
+        &nbsp; | &nbsp;
         
         <%-- summary page --%>
         <a 

--- a/cysec-platform-core/src/main/webapp/app/js/coach.js
+++ b/cysec-platform-core/src/main/webapp/app/js/coach.js
@@ -38,18 +38,20 @@ const updateAnswer = (event) => {
         body: answer,
         credentials: "include",
     }).then(response => {
+        $("#next-button").prop("disabled", false);
         if (response.ok) {
             load()
         } else {
             console.debug(response.status);
             displayError("Couldn't update answer on: " + url + ": " + response.status);
-            $("#next-button").prop("disabled", false);
         }
     }).catch(e => {
         console.debug(e);
         $("#next-button").prop("disabled", false);
     });
-    // disable the next button to avoid jumping to the wrong question
+    /* disable the next button while submitting answer to ensure
+       the server will not route the user (request to .../next) to a
+       wrong question by using the "old state". */
     $("#next-button").prop("disabled", true);
 };
 


### PR DESCRIPTION
The link target of the next button is not depending on the provided answers anymore. A new API route `rest/coaches/{id}/questions/{qid}/next` handles redirecting the user to the correct next question now.